### PR TITLE
Avoid vertival shift when panning map.

### DIFF
--- a/ecoroofs/static/base.scss
+++ b/ecoroofs/static/base.scss
@@ -7,7 +7,8 @@
 
 html, body {
     height: 100%;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
     margin: 0;
     padding: 0;
 }


### PR DESCRIPTION
Avoid vertical map shift seen during scrollbar display/panning due
to horizontal scrollbar being added to body.
