### PR TITLE
Add alternative postgis Dockerfile.

### DIFF
--- a/docker-compose-9.6-2.3.yml
+++ b/docker-compose-9.6-2.3.yml
@@ -1,0 +1,55 @@
+version: "2"
+
+volumes:
+  postgres:
+    external:
+      name: ecoroofs_postgres_data
+
+services:
+  ecoroofs:
+    image: ecoroofs
+    build:
+      context: .
+    command: /webapps/ecoroofs/venv/bin/python manage.py runserver 0.0.0.0:8000
+    environment:
+      - LOCAL_SETTINGS_FILE=local.docker.cfg
+      - WSGI_ROOT=/webapps/ecoroofs/src
+      - WSGI_VENV=/webapps/ecoroofs/venv
+    expose:
+      - 8000
+    ports:
+      - 8000:8000
+    volumes:
+      - .:/webapps/ecoroofs/src
+    depends_on:
+      - base
+      - geoserver
+      - database
+    links:
+      - geoserver
+      - database
+  base:
+    image: django-mod_wsgi-postgres
+    build:
+      context: ./docker/django-mod_wsgi-postgres
+  geoserver:
+    image: geoserver
+    build:
+      context: ./docker/geoserver
+    ports:
+      - 8080:80
+    volumes:
+      - ./geoserver/data_dir:/opt/geoserver_data_dir
+    depends_on:
+      - database
+    links:
+      - database
+  database:
+      image: ecoroofs-postgres:9.6
+      build:
+        context: ./docker/ecoroofs-postgres
+        dockerfile: Dockerfile-9.6-2.3
+      ports:
+        - 5432:5432
+      volumes:
+        - postgres:/var/lib/postgresql/data

--- a/docker/ecoroofs-postgres/Dockerfile-9.6-2.3
+++ b/docker/ecoroofs-postgres/Dockerfile-9.6-2.3
@@ -1,0 +1,14 @@
+FROM postgres:9.6
+
+ENV POSTGIS_MAJOR 2.3
+ENV POSTGIS_VERSION 2.3.0+dfsg-2.pgdg80+1
+
+RUN apt-get update \
+      && apt-get install -y --no-install-recommends \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts=$POSTGIS_VERSION \
+           postgis=$POSTGIS_VERSION \
+      && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /docker-entrypoint-initdb.d
+COPY ./initdb.sh /docker-entrypoint-initdb.d


### PR DESCRIPTION
In order to facilitate easily spawning a development environment,
add a Dockerfile specifying postgres 9.6 and postgis 2.3 and an
alternative docker-compose file.

To use the alternative setup run:
$ docker-compose build -f docker-compose-9.6-2.3.yml
$ docker-compose up -f docker-compose-9.6-2.3.yml

Note: you may need to remove your old docker
volume if it was instantiated with postgres 9.4.
$ docker volume rm ecoroofs_postgres_data.
You will be prompted to recreate the volume when you rebuild.